### PR TITLE
Updated docs for cotraining, clustering, splitae, and utils

### DIFF
--- a/mvlearn/cluster/mv_k_means.py
+++ b/mvlearn/cluster/mv_k_means.py
@@ -29,7 +29,7 @@ class MultiviewKMeans(BaseCluster):
     This algorithm currently handles two views of data.
 
     Parameters
-    ---------
+    ----------
     n_clusters : int, optional, default=2
         The number of clusters
 
@@ -62,8 +62,8 @@ class MultiviewKMeans(BaseCluster):
 
     References
     ----------
-    [1] Bickel S, Scheffer T (2004) Multi-view clustering. Proceedings of the
-    4th IEEE International Conference on Data Mining, pp. 19–26
+    .. [#2Clu] Bickel S, Scheffer T (2004) Multi-view clustering. Proceedings
+            of the 4th IEEE International Conference on Data Mining, pp. 19–26
     '''
 
     def __init__(self, n_clusters=2, random_state=None,

--- a/mvlearn/cluster/mv_spectral.py
+++ b/mvlearn/cluster/mv_spectral.py
@@ -54,8 +54,9 @@ class MultiviewSpectralClustering(BaseEstimator):
 
     References
     ----------
-    [1] Abhishek Kumar and Hal Daume. A Co-training Approach for Multiview
-    Spectral Clustering. In International Conference on Machine Learning, 2011
+    .. [#1Clu] Abhishek Kumar and Hal Daume. A Co-training Approach for
+            Multiview Spectral Clustering. In International Conference on
+            Machine Learning, 2011
 
     '''
 

--- a/mvlearn/cotraining/base.py
+++ b/mvlearn/cotraining/base.py
@@ -54,7 +54,7 @@ class BaseCoTrainEstimator(BaseEstimator):
     def __init__(self,
                  estimator1=None,
                  estimator2=None,
-                 random_state=0
+                 random_state=None
                  ):
         self.estimator1 = estimator1
         self.estimator2 = estimator2

--- a/mvlearn/cotraining/ctclassifier.py
+++ b/mvlearn/cotraining/ctclassifier.py
@@ -21,45 +21,45 @@ from ..utils.utils import check_Xs, check_Xs_y_nan_allowed
 
 
 class CTClassifier(BaseCoTrainEstimator):
-    """
+    r"""
     Co-Training Classifier
 
-    This class implements the co-training classifier with the framework as
-    described in [1]. This should ideally be used on 2 views of the input
-    data which satisfy the 3 conditions for multi-view co-training
-    (sufficiency, compatibility, conditional independence) as detailed in [1].
-    Extends BaseCoTrainEstimator.
+    This class implements the co-training classifier for semi-supervised
+    learning with the framework as described in [#1CTC]_. This should ideally
+    be used on 2 views of the input data which satisfy the 3 conditions for
+    multi-view co-training (sufficiency, compatibility, conditional
+    independence) as detailed in [#1CTC]_. Extends BaseCoTrainEstimator.
 
     Parameters
     ----------
-    estimator1 : classifier object, default (sklearn GaussianNB)
+    estimator1 : classifier object, (default=sklearn GaussianNB)
         The classifier object which will be trained on view 1 of the data.
         This classifier should support the predict_proba() function so that
         classification probabilities can be computed and co-training can be
         performed effectively.
 
-    estimator2 : classifier object, default (sklearn GaussianNB)
+    estimator2 : classifier object, (default=sklearn GaussianNB)
         The classifier object which will be trained on view 2 of the data.
-        Does not need to be of the same type as estimator1, but should support
-        predict_proba().
+        Does not need to be of the same type as ``estimator1``, but should
+        support predict_proba().
 
     p : int, optional (default=None)
         The number of positive classifications from the unlabeled_pool
         training set which will be given a positive "label". If None, the
         default is the floor of the ratio of positive to negative examples
-        in the labeled training data (at least 1). If only one of p or n
-        is not None, the other will be set to be the same. When the labels
-        are 0 or 1, positive is defined as 1, and in general, positive is
-        the larger label.
+        in the labeled training data (at least 1). If only one of ``p`` or
+        ``n`` is not None, the other will be set to be the same. When the
+        labels are 0 or 1, positive is defined as 1, and in general, positive
+        is the larger label.
 
     n : int, optional (default=None)
         The number of negative classifications from the unlabeled_pool
         training set which will be given a negative "label". If None, the
         default is the floor of the ratio of positive to negative examples
-        in the labeled training data (at least 1). If only one of p or n
-        is not None, the other will be set to be the same. When the labels
-        are 0 or 1, negative is defined as 0, and in general, negative is
-        the smaller label.
+        in the labeled training data (at least 1). If only one of ``p`` or
+        ``n`` is not None, the other will be set to be the same. When the
+        labels are 0 or 1, negative is defined as 0, and in general, negative
+        is the smaller label.
 
     unlabeled_pool_size : int, optional (default=75)
         The number of unlabeled_pool samples which will be kept in a
@@ -69,7 +69,7 @@ class CTClassifier(BaseCoTrainEstimator):
     num_iter : int, optional (default=50)
         The maximum number of training iterations to run.
 
-    random_state : int
+    random_state : int (default=None)
         The starting random seed for fit() and class operations, passed to
         numpy.random.seed().
 
@@ -111,15 +111,48 @@ class CTClassifier(BaseCoTrainEstimator):
     num_iter_ : int
         Maximum number of training iterations to run.
 
-    random_state : int
+    random_state : int (default=None)
         The starting random seed for fit() and class operations, passed to
         numpy.random.seed().
 
+    Notes
+    -----
+    Multi-view co-training is most helpful for tasks in semi-supervised where
+    each view offers unique information not seen in the other. As is shown in
+    the example notebooks for using this algorithm, multi-view co-training
+    can provide good classification results even when number of unlabeled
+    samples far exceeds the number of labeled samples. The algorithm, as first
+    proposed by Blum and Mitchell is the following.
+
+    *Algorithm*
+
+    Given:
+
+        * a set *L* of labeled training samples (with 2 views)
+        * a set *U* of unlabeled samples (with 2 views)
+
+    Create a pool *U'* of examples by choosing *u* examples at random
+    from *U*
+
+    Loop for *k* iterations
+
+        * Use *L* to train a classifier *h1* (``estimator1``) that considers
+          only the view 1 portion of the data (i.e. Xs[0])
+        * Use *L* to train a classifier *h2* (``estimator2``) that considers
+          only the view 2 portion of the data (i.e. Xs[1])
+        * Allow *h1* to label *p* (``self.p_``) positive and *n* (``self.n_``)
+          negative samples from view 1 of *U'*
+        * Allow *h2* to label *p* positive and *n* negative samples
+          from view 2 of *U'*
+        * Add these self-labeled samples to *L*
+        * Randomly take 2*p* + 2*n* samples from *U* to replenish *U'*
+
     References
     ----------
-    .. [#1] Blum, A., & Mitchell, T. (1998, July). Combining labeled and
-    unlabeled_pool data with co-training. In Proceedings of the eleventh
-    annual conference on Computational learning theory (pp. 92-100). ACM.
+    .. [#1CTC] Blum, A., & Mitchell, T. (1998, July). Combining labeled and
+            unlabeled_pool data with co-training. In Proceedings of the
+            eleventh annual conference on Computational learning theory
+            (pp. 92-100). ACM.
 
     """
 
@@ -131,7 +164,7 @@ class CTClassifier(BaseCoTrainEstimator):
                  n=None,
                  unlabeled_pool_size=75,
                  num_iter=50,
-                 random_state=0
+                 random_state=None
                  ):
 
         # initialize a BaseCTEstimator object
@@ -161,7 +194,7 @@ class CTClassifier(BaseCoTrainEstimator):
         self._check_params()
 
     def _check_params(self):
-        """
+        r"""
         Checks that cotraining parameters are valid. Throws AttributeError
         if estimators are invalid. Throws ValueError if any other parameters
         are not valid. The checks performed are:
@@ -193,7 +226,7 @@ class CTClassifier(BaseCoTrainEstimator):
             Xs,
             y
             ):
-        """
+        r"""
         Fit the classifier object to the data in Xs, y.
 
         Parameters
@@ -220,8 +253,8 @@ class CTClassifier(BaseCoTrainEstimator):
                                        num_classes=2)
 
         y = np.array(y)
-
-        np.random.seed(self.random_state)
+        if self.random_state is not None:
+            np.random.seed(self.random_state)
 
         self.classes_ = list(set(y[~np.isnan(y)]))
         self.n_classes_ = len(self.classes_)
@@ -320,7 +353,7 @@ class CTClassifier(BaseCoTrainEstimator):
         return self
 
     def predict(self, Xs):
-        """
+        r"""
         Predict the classes of the examples in the two input views.
 
         Parameters
@@ -332,10 +365,31 @@ class CTClassifier(BaseCoTrainEstimator):
 
         Returns
         -------
-        y : array-like (n_samples,)
+        y_pred : array-like (n_samples,)
             The predicted class of each input example. If the two classifiers
             don't agree, pick the one with the highest predicted probability
             from predict_proba()
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from sklearn.model_selection import train_test_split
+        >>> from mvlearn.cotraining.ctclassifier import CTClassifier
+        >>> from mvlearn.datasets.base import load_UCImultifeature
+        >>> data, labels = load_UCImultifeature(select_labeled=[0,1])
+        >>> X1, X2 = data[0], data[1]  # Use the first 2 views
+        >>> X1_train, X1_test, l_train, l_test = train_test_split(X1, labels)
+        >>> X2_train, X2_test, _, _ = train_test_split(X2, labels)
+        >>> remove_idx = np.random.rand(len(l_train),) < 0.97
+        >>> l_train[remove_idx] = np.nan  # simulate semi-supervised
+        >>> label_ratio = len(np.where(remove_idx==False)) / len(l_train)
+        >>> print('%.3f' % label_ratio)  # check labeled data proportion
+        0.030
+        >>> ctc = CTClassifier()
+        >>> ctc.fit([X1_train, X2_train], l_train)
+        >>> y_pred = ctc.predict([X1_test, X2_test])
+        >>> print(y_pred[:10])  # first 10 predictions
+        [0. 0. 1. 0. 1. 1. 0. 0. 0. 0.]
         """
 
         Xs = check_Xs(Xs,
@@ -371,7 +425,7 @@ class CTClassifier(BaseCoTrainEstimator):
         return y_pred
 
     def predict_proba(self, Xs):
-        """
+        r"""
         Predict the probability of each example belonging to a each class.
 
         Parameters

--- a/mvlearn/cotraining/ctclassifier.py
+++ b/mvlearn/cotraining/ctclassifier.py
@@ -22,8 +22,6 @@ from ..utils.utils import check_Xs, check_Xs_y_nan_allowed
 
 class CTClassifier(BaseCoTrainEstimator):
     r"""
-    Co-Training Classifier
-
     This class implements the co-training classifier for semi-supervised
     learning with the framework as described in [#1CTC]_. This should ideally
     be used on 2 views of the input data which satisfy the 3 conditions for
@@ -121,8 +119,18 @@ class CTClassifier(BaseCoTrainEstimator):
     each view offers unique information not seen in the other. As is shown in
     the example notebooks for using this algorithm, multi-view co-training
     can provide good classification results even when number of unlabeled
-    samples far exceeds the number of labeled samples. The algorithm, as first
-    proposed by Blum and Mitchell is the following.
+    samples far exceeds the number of labeled samples. This classifier uses 2
+    classifiers which work individually on each view but which share
+    information and thus result in improved performance over looking at the
+    views completely separately or even when concatenating the views to get
+    more features in a single-view setting. The classifier can be initialized
+    with or without the classifiers desired for each view being specified, but
+    if the classifier for a certain view is specified, then it must support a
+    predict_proba() method in order to give a sense of the most likely labels
+    for different examples. This is because the algorithm must be able to
+    determine which of the training samples it is most confident about during
+    training epochs. The algorithm, as first proposed by Blum and Mitchell, is
+    described in detail below.
 
     *Algorithm*
 

--- a/mvlearn/datasets/base.py
+++ b/mvlearn/datasets/base.py
@@ -5,9 +5,9 @@ import numpy as np
 def load_UCImultifeature(select_labeled="all"):
     """
     Load the UCI multiple features dataset, taken from
-    https://archive.ics.uci.edu/ml/datasets/Multiple+Features
-    This data set consists of 6 views of handwritten digit images, with
-    classes 0-9. The 6 views are the following:
+    https://archive.ics.uci.edu/ml/datasets/Multiple+Features This data set
+    consists of 6 views of handwritten digit images, with classes 0-9. The
+    6 views are the following:
 
     1. 76 Fourier coefficients of the character shapes
     2. 216 profile correlations
@@ -36,9 +36,9 @@ def load_UCImultifeature(select_labeled="all"):
 
     References
     ----------
-    [1] M. van Breukelen, R.P.W. Duin, D.M.J. Tax, and J.E. den Hartog,
-    Handwritten digit recognition by combined classifiers, Kybernetika,
-    vol. 34, no. 4, 1998, 381-386
+    .. [#1Data] M. van Breukelen, R.P.W. Duin, D.M.J. Tax, and J.E. den Hartog,
+            Handwritten digit recognition by combined classifiers, Kybernetika,
+            vol. 34, no. 4, 1998, 381-386
     """
 
     if select_labeled == "all":

--- a/mvlearn/embed/splitae.py
+++ b/mvlearn/embed/splitae.py
@@ -230,7 +230,7 @@ class SplitAE(BaseEmbed):
              - Xs[0] shape: (n_samples, n_features_0)
 
         Returns
-        ----------
+        -------
         embedding: np.ndarray of shape (n_samples, embeddingSize)
             the embedding of the View1 data
         view1_reconstructions: np.ndarray of shape (n_samples, n_features_0)
@@ -253,12 +253,12 @@ class SplitAE(BaseEmbed):
         `fit(Xs)` and then `transform(Xs[:1])`. Note that this method will be
         embedding data that the autoencoder was trained on.
 
-        Parameters:
+        Parameters
         ----------
         Xs: see `fit(...)` Xs parameters
 
         Returns
-        ----------
+        -------
         See `transform(...)` return values.
         """
         self.fit(Xs)

--- a/mvlearn/utils/utils.py
+++ b/mvlearn/utils/utils.py
@@ -19,24 +19,25 @@ import numpy as np
 
 
 def check_Xs(Xs, multiview=False, enforce_views=None):
-    """
+    r"""
     Checks Xs and ensures it to be a list of 2D matrices.
+
     Parameters
     ----------
     Xs : nd-array, list
         Input data.
 
-    multiview : boolean, default (False)
-        Throws error if just 1 data matrix
+    multiview : boolean, (default=False)
+        If True, throws error if just 1 data matrix given.
 
-    enforce_views : int, default (not checked)
+    enforce_views : int, (default=not checked)
         If provided, ensures this number of views in Xs. Otherwise not
         checked.
 
     Returns
     -------
     Xs_converted : object
-        The converted and validated X.
+        The converted and validated X (list of data arrays).
     """
     if not isinstance(Xs, list):
         if not isinstance(Xs, np.ndarray):
@@ -70,8 +71,9 @@ def check_Xs(Xs, multiview=False, enforce_views=None):
 
 
 def check_Xs_y(Xs, y, multiview=False, enforce_views=None):
-    """
-    Checks Xs and y for consistent length. Xs is set to be of dimension 3
+    r"""
+    Checks Xs and y for consistent length. Xs is set to be of dimension 3.
+
     Parameters
     ----------
     Xs : nd-array, list
@@ -80,16 +82,17 @@ def check_Xs_y(Xs, y, multiview=False, enforce_views=None):
     y : nd-array, list
         Labels.
 
-    multiview : boolean, default (False)
-        Throws error if just 1 data matrix.
+    multiview : boolean, (default=False)
+        If True, throws error if just 1 data matrix given.
 
-    enforce_views : int, default (not checked)
+    enforce_views : int, (default=not checked)
         If provided, ensures this number of views in Xs. Otherwise not
         checked.
+
     Returns
     -------
     Xs_converted : object
-        The converted and validated X.
+        The converted and validated X (list of data arrays).
 
     y_converted : object
         The converted and validated y.
@@ -108,17 +111,18 @@ def check_Xs_y_nan_allowed(
         enforce_views=None,
         num_classes=None
         ):
-    """
-    Checks Xs and y for consistent length. Xs is set to be of dimension 3
+    r"""
+    Checks Xs and y for consistent length. Xs is set to be of dimension 3.
+
     Parameters
     ----------
     Xs : nd-array, list
         Input data.
     y : nd-array, list
         Labels.
-    multiview : boolean, default (False)
-        Throws error if just 1 data matrix
-    enforce_views : int, default (not checked)
+    multiview : boolean, (default=False)
+        If True, throws error if just 1 data matrix given.
+    enforce_views : int, (default=not checked)
         If provided, ensures this number of views in Xs. Otherwise not
         checked.
     num_classes: int, default (None)
@@ -128,7 +132,7 @@ def check_Xs_y_nan_allowed(
     Returns
     -------
     Xs_converted : object
-        The converted and validated X.
+        The converted and validated X (list of data arrays).
     y_converted : object
         The converted and validated y.
     """

--- a/tests/test_ctclassifier.py
+++ b/tests/test_ctclassifier.py
@@ -182,7 +182,7 @@ def test_predict_check_p_n(data):
     labels1[:5] = 4 # 5 "negative"
     labels1[5:15] = 6 # 10 "positive"
     labels1[15:] = np.nan
-    clf = CTClassifier()
+    clf = CTClassifier(random_state=0)
     clf.fit(data['random_data'], labels1)
     assert clf.p_ == 2
     assert clf.n_ == 1
@@ -191,7 +191,7 @@ def test_predict_check_p_n(data):
     labels2[:5] = 6 # 5 "positive"
     labels2[5:15] = 4 # 10 "negative"
     labels2[15:] = np.nan
-    clf = CTClassifier()
+    clf = CTClassifier(random_state=0)
     clf.fit(data['random_data'], labels2)
     assert clf.p_ == 1
     assert clf.n_ == 2
@@ -200,7 +200,7 @@ def test_predict_check_p_n(data):
     labels1[:5] = 4 # 5 "negative"
     labels1[5:15] = 6 # 10 "positive"
     labels1[15:] = np.nan
-    clf = CTClassifier(p=4, n=3)
+    clf = CTClassifier(p=4, n=3, random_state=0)
     clf.fit(data['random_data'], labels1)
     assert clf.p_ == 4
     assert clf.n_ == 3


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #93 

#### What does this implement/fix? Explain your changes.
This adds more description to the docs for CoTrainingClassifier, such as adding more description of the use cases and the exact algorithm that it implements. The docs will also now include rendered in-line examples of how to use the fit() and predict() functions. 

Additionally, it fixes several issues with references rendering correctly in the sphinx docs for cotraining, clustering, splitae, and embed methods.

#### Any other comments?
I also fixed the usage of random_state parameter in the ctclassifier, which previously had a default value of 0 but now is default None.
